### PR TITLE
fix function scopes when using pipes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestHandcalcFunctions = "6ba57fb7-81df-4b24-8e8e-a3885b6fcae7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulLatexify = "45397f5d-5981-4c77-b2b3-fc36d6e9b728"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [targets]
-test = ["Test", "Unitful", "UnitfulLatexify", "TestHandcalcFunctions"]
+test = ["Test", "Unitful", "UnitfulLatexify", "TestHandcalcFunctions", "Revise"]

--- a/src/handfunc_macro.jl
+++ b/src/handfunc_macro.jl
@@ -60,6 +60,11 @@ function _walk_func_body(expr::Expr, found_module)
 
     prewalk(expr) do x
         if @capture(x, f_(args__))
+
+            # if f is |>, need to make sure function after |> gets properly scoped
+            if f == :(|>) 
+                x.args[3] = Meta.parse(found_module_string * "." * string(x.args[3]))
+            end
             len = length(collect(Leaves(f)))
             if len == 1
                 if isdefined(Main, f) # should really be `Base` but `Main` is used for now

--- a/test/FunctionTestModule.jl
+++ b/test/FunctionTestModule.jl
@@ -1,0 +1,17 @@
+module FunctionTestModule
+using Unitful
+
+module cnv
+    using Unitful
+    to_L(x) = x |> u"inch"
+end
+    
+function add_cnv(a, b)
+    c = a + b |> cnv.to_L
+end
+
+function add_inch(a, b)
+    c = a + b |> u"inch"
+end
+
+end

--- a/test/handfunc_macro.jl
+++ b/test/handfunc_macro.jl
@@ -202,3 +202,18 @@ c1, c2 &= \mathrm{\mathrm{\mathrm{TestHandcalcFunctions}\left( SubA \right)}\lef
 calc = @handcalcs result = TestHandcalcFunctions.test_function_finder(5, 15) not_funcs = [:calc_Iy :sub_module_func] 
 @test calc == replace(expected, "\r" => "") # for whatever reason the expected had addittional carriage returns (\r)
 # ***************************************************
+
+# Check piped functions not in scope
+# ***************************************************
+# ***************************************************
+a = 5*u"inch"
+b = 6*u"inch"
+calc = @handcalcs result = FunctionTestModule.add_cnv(a, b)
+calc2 = @handcalcs result = FunctionTestModule.add_inch(a, b)
+expected = L"$\begin{aligned}
+c &= a + b = 5\;\mathrm{inch} + 6\;\mathrm{inch} = 11\;\mathrm{inch}
+\end{aligned}$"
+@test calc == expected
+@test calc2 == expected
+# ***************************************************
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Handcalcs
 using LaTeXStrings, Unitful, UnitfulLatexify
 using Test
 using TestHandcalcFunctions
+using Revise
+isdefined(Main, :Revise) ? Main.Revise.includet("FunctionTestModule.jl") : include("FunctionTestModule.jl")
 # using .TestFunctions
 
 


### PR DESCRIPTION
There is currently an issue when using `|>` in function bodies. This pull request adds the proper scopes to functions that are called using piping syntax