### PR TITLE
add precision option

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -48,6 +48,7 @@ The moment of inertia about the y direction is: $I_y\n")
 - `spa` - change the vertical line spacing between expressions (default = 10).
 - `color`: change the color of the output (`:blue`, `:red`, etc)
 - `h_env` - change the environment (default = "aligned").
+- `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `len` - change expression to write to multiple lines using `len=:long` (default = :short).
 
 **Note: `@handcalcs` macro can also take symbols of defined variables. See below.**
@@ -151,9 +152,10 @@ You can change the default settings using the `set_handcalcs` function *(similar
 - `len`: can set to `:long` and it will split equation to multiple lines
 - `color`: change the color of the output (`:blue`, `:red`, etc)
 - `h_env`: choose between "aligned" (default), "align" and other LaTeX options
+- `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `not_funcs`: name the functions you do not want to "unroll" 
 - `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
-- disable: disable handcalcs rendering to run simulations and turn it back on when needed.
+- `disable`: disable handcalcs rendering to run simulations and turn it back on when needed.
 
 ```julia
 set_handcalcs(cols=3)
@@ -183,12 +185,35 @@ reset_handcalcs()
 
 ### Set default precision
 
-Currently, to set the default precision, use the `set_default` function in combination with the [Format.jl](https://github.com/JuliaString/Format.jl) package. The `set_default` function is re-exported from the Latexify.jl package. See [here](https://korsbo.github.io/Latexify.jl/stable/#Setting-your-own-defaults) for more Latexify default settings. This is what I primarily use for now (you can see the use in the gif on the github page):
+Handcalcs provides a setting to include a default precision. This setting formats a number to a max precision. See example below:
+
+```@example main
+@handcalcs begin
+    a = 2.567
+    b = 2.5
+    c = 1
+    d = true
+end precision = 2
+```
+
+This setting is off by default, but you can add a default with the `set_handcalcs` function.
 
 ```julia
-using Format
-set_default(fmt = x->format(round(x, digits=4)))
+set_handcalcs(precision=4)
 ```
+
+If other formats are preferred, then use the `fmt` option provided by Latexify. 
+
+```@example main
+@handcalcs begin
+    a = 2.567
+    b = 2.5
+    c = 1
+    d = true
+end fmt = "%.2f"
+```
+
+The `set_default` function is re-exported from the Latexify.jl package. See [here](https://korsbo.github.io/Latexify.jl/stable/#Setting-your-own-defaults) for more Latexify default settings.
 
 ## Using Unitful with UnitfulLatexify
 

--- a/src/Handcalcs.jl
+++ b/src/Handcalcs.jl
@@ -1,6 +1,6 @@
 module Handcalcs
 
-using Latexify: latexify, set_default, get_default, reset_default, @latexdefine
+using Latexify: latexify, set_default, get_default, reset_default, @latexdefine, AbstractNumberFormatter
 using MacroTools: postwalk, prewalk
 using MacroTools
 using LaTeXStrings
@@ -10,7 +10,7 @@ import AbstractTrees: Leaves, PostOrderDFS
 using PrecompileTools: @setup_workload, @compile_workload 
 
 export @handcalc, @handcalcs, @handfunc, multiline_latex, collect_exprs
-export set_handcalcs, reset_handcalcs, get_handcalcs #, initialize_format
+export set_handcalcs, reset_handcalcs, get_handcalcs, PrecisionNumberFormatter
 export latexify, @latexdefine, set_default, get_default, reset_default
 
 # function initialize_format()
@@ -28,8 +28,9 @@ const math_syms = [
     :cumsum, :max, :min, :exp, :log,
     :log10, :√]
     
-const h_syms = [:cols, :spa, :h_env, :len, :color, :disable]
+const h_syms = [:cols, :spa, :h_env, :len, :color, :disable, :parse_pipe]
 
+include("numberformatters.jl")
 include("default_h_kwargs.jl")
 include("handcalc_marco.jl")
 include("handcalcs_macro.jl")

--- a/src/default_h_kwargs.jl
+++ b/src/default_h_kwargs.jl
@@ -9,14 +9,15 @@ This works for all keyword arguments. It is additive such that if
 you call it multiple times, defaults will be added or replaced, but not reset.
 
 ## Kwargs
-- cols: sets the number of columns in the output
-- spa: sets the line spacing
-- len: can set to `:long` and it will split equation to multiple lines
-- color: change the color of the output (`:blue`, `:red`, etc)
-- h_env: choose between "aligned" (default), "align" and other LaTeX options
-- not_funcs: name the functions you do not want to "unroll" 
-- parse_pipe: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
-- disable: disable handcalcs rendering to run simulations and turn it back on when needed.
+- `cols`: sets the number of columns in the output
+- `spa`: sets the line spacing
+- `len`: can set to `:long` and it will split equation to multiple lines
+- `color`: change the color of the output (`:blue`, `:red`, etc)
+- `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
+- `h_env`: choose between "aligned" (default), "align" and other LaTeX options
+- `not_funcs`: name the functions you do not want to "unroll" 
+- `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
+- `disable`: disable handcalcs rendering to run simulations and turn it back on when needed.
 
 Example: 
 ```julia
@@ -45,13 +46,14 @@ reset_handcalcs() = empty!(default_h_kwargs)
 Get a Dict with the user-specified default kwargs for handcalcs, set by `set_handcalcs`.
 
 ## Kwargs
-- cols: sets the number of columns in the output
-- spa: sets the line spacing
-- len: can set to `:long` and it will split equation to multiple lines
-- h_env: Choose between "aligned" (default), "align" and other LaTeX options
-- not_funcs: Name the functions you do not want to "unroll" 
-- parse_pipe: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
-- disable: disable handcalcs rendering to run simulations and turn it back on when needed.
+- `cols`: sets the number of columns in the output
+- `spa`: sets the line spacing
+- `len`: can set to `:long` and it will split equation to multiple lines
+- `h_env`: Choose between "aligned" (default), "align" and other LaTeX options
+- `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
+- `not_funcs`: Name the functions you do not want to "unroll" 
+- `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
+- `disable`: disable handcalcs rendering to run simulations and turn it back on when needed.
 """
 function get_handcalcs end
 get_handcalcs() = default_h_kwargs

--- a/src/handcalcs_macro.jl
+++ b/src/handcalcs_macro.jl
@@ -149,15 +149,29 @@ function clean_kwargs(kwargs)
     is_recursive = false
     h_kwargs = []
     l_kwargs = []
+    overwrite_precision = false
     for kwarg in kwargs
         split_kwarg = _split_kwarg(kwarg)
         if split_kwarg in h_syms
             h_kwargs = push!(h_kwargs, kwarg)
         elseif split_kwarg == :is_recursive
             is_recursive = true
+        elseif split_kwarg == :precision
+            overwrite_precision = true
+            precision = kwarg.args[2]
+            l_kwargs = push!(l_kwargs, :(fmt = PrecisionNumberFormatter($precision)))
+        elseif split_kwarg == :fmt
+            overwrite_precision = true
+            l_kwargs = push!(l_kwargs, kwarg)
         else
             l_kwargs = push!(l_kwargs, kwarg)
         end
+    end
+
+    # use default precision if not fmt or precision is given
+    if !overwrite_precision && haskey(default_h_kwargs, :precision)
+        precision = default_h_kwargs[:precision]
+        l_kwargs = push!(l_kwargs, :(fmt = PrecisionNumberFormatter($precision)))
     end
     return is_recursive, Tuple(h_kwargs), Tuple(l_kwargs)
 end

--- a/src/numberformatters.jl
+++ b/src/numberformatters.jl
@@ -1,0 +1,17 @@
+import Latexify
+
+precision_format(precision::Integer) = x -> Latexify.Format.format(round(x, RoundNearestTiesAway, digits=precision))
+
+struct PrecisionNumberFormatter <: AbstractNumberFormatter
+    precision::Integer
+    f::Function
+
+    PrecisionNumberFormatter(precision::Integer) = new(precision, precision_format(precision))
+end
+
+(f::PrecisionNumberFormatter)(x::Real) = f.f(x)
+
+(f::PrecisionNumberFormatter)(x::Bool) = string(x)
+
+
+

--- a/test/default_h_kwargs.jl
+++ b/test/default_h_kwargs.jl
@@ -45,3 +45,48 @@ Ix &= \mathrm{calc}_{Ix}\left( 5, 15 \right) = 1406.25
 calc = @handcalcs Ix = calc_Ix(5, 15)
 @test calc == expected
 reset_handcalcs()
+
+
+# use set_handcalcs for precision
+# ***************************************************
+# ***************************************************
+set_handcalcs(precision = 1)
+
+expected =L"\begin{aligned}
+x &= 5.3
+\\[10pt]
+y &= 4
+\end{aligned}"
+
+calc = @handcalcs begin
+    x = 5.25
+    y = 4
+end
+@test calc == expected
+
+# make sure default precision does not overwrite given values
+expected =L"\begin{aligned}
+x &= 5.2565
+\\[10pt]
+y &= 4
+\end{aligned}"
+
+calc = @handcalcs begin
+    x = 5.25645
+    y = 4
+end precision = 4
+@test calc == expected
+
+
+expected =L"\begin{aligned}
+x &= 5.2565
+\\[10pt]
+y &= 4.0000
+\end{aligned}"
+
+calc = @handcalcs begin
+    x = 5.25645
+    y = 4
+end fmt = "%.4f"
+@test calc == expected
+reset_handcalcs()


### PR DESCRIPTION
# Feature Added

This pull request adds a `precision` option to set the formatting for the numbers.  This setting formats numbers to a max precision.  Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`. See below for an example.

```julia-repl
julia> @handcalcs begin
           a = 2.567
           b = 2.5
           c = 1
           d = true
       end precision = 2
L"$\begin{aligned}
a &= 2.57
\\[10pt]
b &= 2.5
\\[10pt]
c &= 1
\\[10pt]
d &= true
\end{aligned}$"
```