### PR TITLE
add left_align function for pluto

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -238,3 +238,29 @@ t = 8.5u"inch"
     Ix = b*t^3/12   |> u"inch"^4
 end
 ```
+
+## Pluto
+
+Handcalcs renders in [Pluto.jl](https://plutojl.org/). There is one function specifically for rendering in pluto.
+
+```@docs
+left_align_in_pluto
+```
+
+!!! note "Use `begin` and `end`"
+    Pluto outputs an extra variable description when using `@handcalcs` without `begin` and `end`.
+    
+    As an example:
+
+    ```julia
+    @handcalcs x = 2
+    ```
+
+    Instead of writing the code above, write:
+
+    ```julia
+    @handcalcs begin 
+        x = 2 
+    end
+    ```
+

--- a/src/Handcalcs.jl
+++ b/src/Handcalcs.jl
@@ -11,6 +11,7 @@ using PrecompileTools: @setup_workload, @compile_workload
 
 export @handcalc, @handcalcs, @handfunc, multiline_latex, collect_exprs
 export set_handcalcs, reset_handcalcs, get_handcalcs, PrecisionNumberFormatter
+export left_align_in_pluto
 export latexify, @latexdefine, set_default, get_default, reset_default
 
 # function initialize_format()
@@ -29,6 +30,19 @@ const math_syms = [
     :log10, :√]
     
 const h_syms = [:cols, :spa, :h_env, :len, :color, :disable, :parse_pipe]
+
+"""
+    left_align_in_pluto()
+
+Returns html that changes mathjax settings in pluto. This results in equations that are left aligned instead of centered.
+"""
+left_align_in_pluto() = html"""
+<style>
+	mjx-container {
+		text-align: left !important;
+	}
+</style>
+"""
 
 include("numberformatters.jl")
 include("default_h_kwargs.jl")

--- a/test/handcalc_macro.jl
+++ b/test/handcalc_macro.jl
@@ -2,6 +2,19 @@
 # using Test
 
 
+# Pluto test
+# ***************************************************
+# ***************************************************
+expected = html"""
+<style>
+	mjx-container {
+		text-align: left !important;
+	}
+</style>
+"""
+calc = left_align_in_pluto()
+@test calc == expected
+
 # Quadratic formula test
 # ***************************************************
 # ***************************************************


### PR DESCRIPTION
# Feature Added

This pull request adds a function that changes the mathjax settings in pluto. This results in equations that are left aligned instead of centered.