### PR TITLE
Add Additional Render Settings

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -215,6 +215,7 @@ You can change the default settings using the `set_handcalcs` function *(similar
 - `len`: can set to `:long` and it will split equation to multiple lines
 - `color`: change the color of the output (`:blue`, `:red`, etc)
 - `h_env`: choose between "aligned" (default), "align" and other LaTeX options
+- `h_render`: choose between "symbolic", "numeric" and "both" (default)
 - `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `not_funcs`: name the functions you do not want to "unroll" 
 - `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
@@ -278,6 +279,35 @@ end fmt = "%.2f"
 ```
 
 The `set_default` function is re-exported from the Latexify.jl package. See [here](https://korsbo.github.io/Latexify.jl/stable/#Setting-your-own-defaults) for more Latexify default settings.
+
+### Set Rendering Format
+
+Handcalcs provides a setting to include a different rendering format. The choices are between `symbolic`, `numeric`, or `both` (default).
+
+See example below for a symbolic rendering:
+
+```@example main
+set_handcalcs(h_render=:symbolic)
+b = 5 # width
+h = 15 # height
+@handcalcs Ix = calc_Ix(b, h) # function is defined in TestHandcalcFunctions package
+```
+
+See example below for a numeric rendering:
+
+```@example main
+set_handcalcs(h_render=:numeric)
+b = 5 # width
+h = 15 # height
+@handcalcs Ix = calc_Ix(b, h) # function is defined in TestHandcalcFunctions package
+```
+
+This is really meant to be a setting overall, but you can use the `set_handcalcs` function to turn the setting on, then use it again afterward to turn it back to the default.
+
+```@example main
+set_handcalcs(h_render=:both) # set handcalcs back to default
+```
+
 
 ## Using Unitful with UnitfulLatexify
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -215,7 +215,7 @@ You can change the default settings using the `set_handcalcs` function *(similar
 - `len`: can set to `:long` and it will split equation to multiple lines
 - `color`: change the color of the output (`:blue`, `:red`, etc)
 - `h_env`: choose between "aligned" (default), "align" and other LaTeX options
-- `h_render`: choose between "symbolic", "numeric" and "both" (default)
+- `h_render`: choose between "equation", symbolic", "numeric" and "both" (default)
 - `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `not_funcs`: name the functions you do not want to "unroll" 
 - `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
@@ -282,7 +282,22 @@ The `set_default` function is re-exported from the Latexify.jl package. See [her
 
 ### Set Rendering Format
 
-Handcalcs provides a setting to include a different rendering format. The choices are between `symbolic`, `numeric`, or `both` (default).
+Handcalcs provides a setting to include a different rendering format. The choices are between `equation`, `symbolic`, `numeric`, or `both` (default).
+
+See example below for an equation rendering:
+
+```@example main
+set_handcalcs(h_render=:equation)
+b = 5 # width
+h = 15 # height
+@handcalcs Ix = calc_Ix(b, h) # function is defined in TestHandcalcFunctions package
+```
+
+Note: `I_x` is evaluated.
+
+```@example main
+@handcalcs I_x
+```
 
 See example below for a symbolic rendering:
 

--- a/src/default_h_kwargs.jl
+++ b/src/default_h_kwargs.jl
@@ -15,6 +15,7 @@ you call it multiple times, defaults will be added or replaced, but not reset.
 - `color`: change the color of the output (`:blue`, `:red`, etc)
 - `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `h_env`: choose between "aligned" (default), "align" and other LaTeX options
+- `h_render`: choose between "symbolic", "numeric" and "both" (default)
 - `not_funcs`: name the functions you do not want to "unroll" 
 - `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
 - `parse_ifs`: a boolean value (default=true) to unroll if statements. Function unrolling works and it only shows the parts of the if statement that were met.

--- a/src/default_h_kwargs.jl
+++ b/src/default_h_kwargs.jl
@@ -15,7 +15,7 @@ you call it multiple times, defaults will be added or replaced, but not reset.
 - `color`: change the color of the output (`:blue`, `:red`, etc)
 - `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `h_env`: choose between "aligned" (default), "align" and other LaTeX options
-- `h_render`: choose between "symbolic", "numeric" and "both" (default)
+- `h_render`: choose between "equation", symbolic", "numeric" and "both" (default)
 - `not_funcs`: name the functions you do not want to "unroll" 
 - `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.
 - `parse_ifs`: a boolean value (default=true) to unroll if statements. Function unrolling works and it only shows the parts of the if statement that were met.
@@ -52,6 +52,7 @@ Get a Dict with the user-specified default kwargs for handcalcs, set by `set_han
 - `spa`: sets the line spacing
 - `len`: can set to `:long` and it will split equation to multiple lines
 - `h_env`: Choose between "aligned" (default), "align" and other LaTeX options
+- `h_render`: choose between "equation", symbolic", "numeric" and "both" (default)
 - `precision`: formats numbers to a max precision. Given `precision = 2`, `2.567` will show as `2.57`, while `2.5` would show as `2.5`
 - `not_funcs`: Name the functions you do not want to "unroll" 
 - `parse_pipe`: a boolean value (default=true) to remove pipe from equation. This is intended for unitful equations.

--- a/src/handcalc_marco.jl
+++ b/src/handcalc_marco.jl
@@ -59,7 +59,7 @@ macro handcalc(expr, kwargs...)
         return _handcalc_symbolic(expr_og, expr, post, kwargs)
     end
     if default_render == :equation  
-        return _handcalc_equation(expr_og, expr, post, kwargs)
+        return _handcalc_equation(expr_og, expr, kwargs)
     end
 
     # compute the numeric values of the expression
@@ -94,7 +94,7 @@ end
 
 # Handcalcs - equation only return
 # ***************************************************
-function _handcalc_equation(expr_og, expr, post, kwargs)
+function _handcalc_equation(expr_og, expr, kwargs)
     return esc(
         Expr(
             :block,

--- a/src/handcalc_marco.jl
+++ b/src/handcalc_marco.jl
@@ -59,7 +59,7 @@ macro handcalc(expr, kwargs...)
         return _handcalc_symbolic(expr_og, expr, post, kwargs)
     end
     if default_render == :equation  
-        return _handcalc_eq_only(expr_og, expr, post, kwargs)
+        return _handcalc_equation(expr_og, expr, post, kwargs)
     end
 
     # compute the numeric values of the expression
@@ -94,7 +94,7 @@ end
 
 # Handcalcs - equation only return
 # ***************************************************
-function _handcalc_eq_only(expr_og, expr, post, kwargs)
+function _handcalc_equation(expr_og, expr, post, kwargs)
     return esc(
         Expr(
             :block,

--- a/test/default_h_kwargs.jl
+++ b/test/default_h_kwargs.jl
@@ -96,6 +96,22 @@ reset_handcalcs()
 # ***************************************************
 # ***************************************************
 
+# equation only return
+set_handcalcs(h_render = :equation)
+expected = L"$\begin{aligned}
+c &= a + b
+\end{aligned}$"
+
+a = 5
+b = 10
+
+calc = @handcalcs begin
+    c = a + b
+end
+@test calc == expected
+@test c == 15
+reset_handcalcs()
+
 # symbolic return
 set_handcalcs(h_render = :symbolic)
 expected = L"$\begin{aligned}

--- a/test/default_h_kwargs.jl
+++ b/test/default_h_kwargs.jl
@@ -90,3 +90,35 @@ calc = @handcalcs begin
 end fmt = "%.4f"
 @test calc == expected
 reset_handcalcs()
+
+
+# use set_handcalcs for h_render
+# ***************************************************
+# ***************************************************
+
+# symbolic return
+set_handcalcs(h_render = :symbolic)
+expected = L"$\begin{aligned}
+c &= a + b = 15
+\end{aligned}$"
+
+a = 5
+b = 10
+
+calc = @handcalcs begin
+    c = a + b
+end
+@test calc == expected
+reset_handcalcs()
+
+# numeric return
+set_handcalcs(h_render = :numeric)
+expected = L"$\begin{aligned}
+c &= 5 + 10 = 15
+\end{aligned}$"
+
+calc = @handcalcs begin
+    c = a + b
+end h_render = :numeric
+@test calc == expected
+reset_handcalcs()

--- a/test/handfunc_macro.jl
+++ b/test/handfunc_macro.jl
@@ -200,7 +200,7 @@ c1, c2 &= \mathrm{TestHandcalcFunctions.SubA.sub}_{module\_func}\left( a, b \rig
 \end{aligned}$"
 
 calc = @handcalcs result = TestHandcalcFunctions.test_function_finder(5, 15) not_funcs = [:calc_Iy :sub_module_func] 
-@test calc == expected # for whatever reason the expected had addittional carriage returns (\r)
+@test calc == replace(expected, "\r" => "") # for whatever reason the expected had addittional carriage returns (\r)
 # ***************************************************
 
 # Check piped functions not in scope


### PR DESCRIPTION
# Feature Added

## New Handcalc Render Settings
A new setting to include a different rendering format. The choices are between `equation`, `symbolic`, `numeric`, or `both` (default).

For example, you can change to an equation only rendering:

```julia
set_handcalcs(h_render=:equation)
```

