### PR TITLE
Add Debugging Capability for Function Unrolling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ TestHandcalcFunctions = "6ba57fb7-81df-4b24-8e8e-a3885b6fcae7"
 [compat]
 AbstractTrees = "0.4"
 CodeTracking = "1.3"
+IOCapture = "0.2.5"
 LaTeXStrings = "1.3"
 Latexify = "^0.16.6"
 MacroTools = "0.5"
@@ -28,11 +29,12 @@ UnitfulLatexify = "^1.6.4"
 julia = "1.10"
 
 [extras]
+IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestHandcalcFunctions = "6ba57fb7-81df-4b24-8e8e-a3885b6fcae7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulLatexify = "45397f5d-5981-4c77-b2b3-fc36d6e9b728"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [targets]
-test = ["Test", "Unitful", "UnitfulLatexify", "TestHandcalcFunctions", "Revise"]
+test = ["Test", "Unitful", "UnitfulLatexify", "TestHandcalcFunctions", "Revise", "IOCapture"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Handcalcs"
 uuid = "e8a07092-c156-4455-ab8e-ed8bc81edefb"
 authors = ["Cole Miller"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -141,6 +141,21 @@ Current Limitations for `@handcalcs`
 
 - I believe the function needs to be defined in another package. The @code_expr macro from CodeTracking.jl does not see functions in Main for some reason.
 
+### Debugging Function Unrolling
+
+It can be difficult to debug function unrolling when `Handcalcs` is unable to properly unroll a function. If you encounter an error, you can use the `show_funcs` keyword. This will print out all the functions `Handcalcs` stepped into. The last function printed should be where the error occured and it can give you a starting point on where to start digging in.
+
+Here is an example:
+
+```@example main
+@handcalcs begin
+I_x, I_y = TestHandcalcFunctions.calc_Is(5, 15)
+end show_funcs = true
+nothing # writing nothing here to show stdout per Documenter.jl
+```
+
+There was no error here, but you can see that `Handcalcs` stepped into `calc_Is`, then `calc_Ix`, and then `calc_Iy`.
+
 ## Options for if statements
 
 If statements have two different formats in how they can be displayed. The default format is different than how Latexify would display the if statement. The reasoning was to show an if statement more like the way you would if you were performing a calculation by hand and to also integrate function unrolling. The default format (`parse_ifs=true`), only shows the branches of the if statement that pass the logic statements within the if statement. This is nice, because you only see the equations that are relevant to that specific problem. See the example below:

--- a/src/handcalcs_macro.jl
+++ b/src/handcalcs_macro.jl
@@ -9,12 +9,13 @@ The RHS can be formatted or otherwise transformed by supplying a function as kwa
 Can also add comments to the end of equations. See example below.
 
 ## Kwargs
-- cols: sets the number of columns in the output
-- spa: sets the line spacing
-- len: can set to `:long` and it will split equation to multiple lines
-- color: change the color of the output (`:blue`, `:red`, etc)
-- h_env: choose between "aligned" (default), "align" and other LaTeX options
-- not_funcs: name the functions you do not want to "unroll" 
+- `cols`: sets the number of columns in the output
+- `spa`: sets the line spacing
+- `len`: can set to `:long` and it will split equation to multiple lines
+- `color`: change the color of the output (`:blue`, `:red`, etc)
+- `h_env`: choose between "aligned" (default), "align" and other LaTeX options
+- `not_funcs`: name the functions you do not want to "unroll" 
+- `show_funcs`: `true` or `false` (default), helps with debugging when getting error during function unrolling.
 
 # Examples
 ```julia-repl

--- a/src/handfunc_macro.jl
+++ b/src/handfunc_macro.jl
@@ -29,6 +29,7 @@ macro handfunc(expr, kwargs...)
         found_module = $(esc(:(Handcalcs.@which $(expr.args[2])))).module
         found_func = $(esc(:(Handcalcs.@code_expr $(expr.args[2]))))
         if is_show_funcs_on($kwargs)
+            # println($(string(expr.args[2])), " = ", $eq)
             @show $eq
         end
         func_args = $(esc(:(Handcalcs.@func_vars $(expr.args[2]))))

--- a/src/handfunc_macro.jl
+++ b/src/handfunc_macro.jl
@@ -28,12 +28,19 @@ macro handfunc(expr, kwargs...)
     return quote
         found_module = $(esc(:(Handcalcs.@which $(expr.args[2])))).module
         found_func = $(esc(:(Handcalcs.@code_expr $(expr.args[2]))))
+        if is_show_funcs_on($kwargs)
+            @show $eq
+        end
         func_args = $(esc(:(Handcalcs.@func_vars $(expr.args[2]))))
         latex_eq = handfunc(found_module, found_func, func_args, $kwargs)
         latex = @eval #=found_module=# $(Expr(:$, :latex_eq))
         $var = $eq
         latex
     end
+end
+
+function is_show_funcs_on(kwargs)
+    :(show_funcs = true) in kwargs
 end
 
 macro func_vars(expr)

--- a/src/handfunc_macro.jl
+++ b/src/handfunc_macro.jl
@@ -29,8 +29,8 @@ macro handfunc(expr, kwargs...)
         found_module = $(esc(:(Handcalcs.@which $(expr.args[2])))).module
         found_func = $(esc(:(Handcalcs.@code_expr $(expr.args[2]))))
         if is_show_funcs_on($kwargs)
-            # println($(string(expr.args[2])), " = ", $eq)
-            @show $eq
+            println($(string(expr.args[2])), " = ", $eq)
+            # @show $eq # this was a bit faster, but worse for readability
         end
         func_args = $(esc(:(Handcalcs.@func_vars $(expr.args[2]))))
         latex_eq = handfunc(found_module, found_func, func_args, $kwargs)

--- a/test/handcalcs_macro.jl
+++ b/test/handcalcs_macro.jl
@@ -351,3 +351,24 @@ end
 
 @test calc == expected
 # ***************************************************
+ 
+ 
+# show_funcs keyword
+# ***************************************************
+# ***************************************************
+expected = L"$\begin{aligned}
+Ix &= \frac{b \cdot h^{3}}{12} = \frac{5 \cdot 15^{3}}{12} = 1406.25
+\\[10pt]
+Iy &= \frac{h \cdot b^{expo}}{denominator} = \frac{15 \cdot 5^{3}}{12} = 156.25
+\end{aligned}$"
+
+stdout_expected = "calc_Is(5, 15) = (1406.25, 156.25)\ncalc_Ix(b, h) = 1406.25\ncalc_Iy(h, b) = 156.25\n"
+c = IOCapture.capture() do
+    calc = @handcalcs begin
+        I_s = calc_Is(5,15)
+    end show_funcs = true
+end
+
+@test c.output == stdout_expected
+@test c.value == expected
+# ***************************************************

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using LaTeXStrings, Unitful, UnitfulLatexify
 using Test
 using TestHandcalcFunctions
 using Revise
+import IOCapture
 isdefined(Main, :Revise) ? Main.Revise.includet("FunctionTestModule.jl") : include("FunctionTestModule.jl")
 # using .TestFunctions
 


### PR DESCRIPTION
# Feature Added

## Add Debugging Capability for Function Unrolling

It can be difficult to debug function unrolling when `Handcalcs` is unable to properly unroll a function. If you encounter an error, you can use the `show_funcs` keyword. This will print out all the functions `Handcalcs` stepped into. The last function printed should be where the error occured and it can give you a starting point on where to start digging in.

Here is an example:

```julia-repl
julia> @handcalcs I_x, I_y = TestHandcalcFunctions.calc_Is(5, 15) show_funcs = true
TestHandcalcFunctions.calc_Is(5, 15) = (1406.25, 156.25)
calc_Ix(b, h) = 1406.25
calc_Iy(h, b) = 156.25
L"$\begin{aligned}
Ix &= \frac{b \cdot h^{3}}{12} = \frac{5 \cdot 15^{3}}{12} = 1406.25
\\[10pt]
Iy &= \frac{h \cdot b^{expo}}{denominator} = \frac{15 \cdot 5^{3}}{12} = 156.25
\end{aligned}$"
```

There was no error here, but you can see that `Handcalcs` stepped into `calc_Is`, then `calc_Ix`, and then `calc_Iy`.