### PR TITLE
Formatter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Handcalcs"
 uuid = "e8a07092-c156-4455-ab8e-ed8bc81edefb"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Cole Miller"]
 
 [deps]

--- a/src/numberformatters.jl
+++ b/src/numberformatters.jl
@@ -1,6 +1,6 @@
 import Latexify
 
-precision_format(precision::Integer) = x -> Latexify.Format.format(round(x, RoundNearestTiesAway, digits=precision))
+precision_format(precision::Integer) = x -> string(round(x, RoundNearestTiesAway, digits=precision))
 
 struct PrecisionNumberFormatter <: AbstractNumberFormatter
     precision::Integer
@@ -10,6 +10,8 @@ struct PrecisionNumberFormatter <: AbstractNumberFormatter
 end
 
 (f::PrecisionNumberFormatter)(x::Real) = f.f(x)
+
+(f::PrecisionNumberFormatter)(x::Integer) = string(x)
 
 (f::PrecisionNumberFormatter)(x::Bool) = string(x)
 


### PR DESCRIPTION
# Bug Fix
Fixes bug with the `precision` setting where floats that are whole numbers look like integers. Now floats like `5.0` will not show as `5` but will remain `5.0`.